### PR TITLE
Bind print-length while saving to avoid truncation

### DIFF
--- a/uptimes.el
+++ b/uptimes.el
@@ -198,7 +198,8 @@ The result is returned as the following `list':
   (interactive)
   (uptimes-update)
   (with-temp-buffer
-    (let ((standard-output (current-buffer)))
+    (let ((standard-output (current-buffer))
+          (print-length nil))
       (pp uptimes-last-n)
       (pp uptimes-top-n)
       ;; TODO: What is the correct method of ignoring a lock error (IOW,


### PR DESCRIPTION
print-length is set to 10 by default in some emacsen, which means that if `uptimes-keep-count` > `print-length`, the save files look like:

```el
(("1523227604.0333686" 1523227604.0333686 . 1523253707.0400088)
 ("1523225219.0412824" 1523225219.0412824 . 1523227601.0918615)
 ("1522010906.0040841" 1522010906.004084 . 1522992934.0698469)
 ("1521692287.0026112" 1521692287.0026112 . 1522010902.0999143)
 ("1521674231.0431931" 1521674231.043193 . 1521690402.0894942)
 ("1521674002.0422325" 1521674002.0422325 . 1521674228.022428)
 ("1521614428.0359979" 1521614428.0359979 . 1521673997.0003824)
 ("1520972695.0044835" 1520972695.0044835 . 1521614426.0138924)
 ("1520897379.0503647" 1520897379.0503647 . 1520972676.048322)
 ("1520805387.0192680" 1520805387.019268 . 1520893156.0360408)
 ...)
```
This commit fixes the issue by making print-length unlimited.