### PR TITLE
Show top and recent uptimes lists separately

### DIFF
--- a/uptimes.el
+++ b/uptimes.el
@@ -1,9 +1,8 @@
-;;; uptimes.el --- Track and display emacs session uptimes.
+;;; uptimes.el --- Track and display emacs session uptimes. -*- lexical-binding: t -*-
 ;; Copyright 1999-2018 by Dave Pearson <davep@davep.org>
 
 ;; Author: Dave Pearson <davep@davep.org>
 ;; Version: 3.6
-;; Package-Version: 20180416.1323
 ;; Keywords: processes, uptime
 ;; URL: https://github.com/davep/uptimes.el
 ;; Package-Requires: ((cl-lib "0.5") (emacs "24"))
@@ -24,7 +23,7 @@
 ;;; Commentary:
 ;;
 ;; uptimes.el provides a simple system for tracking and displaying the
-;; uptimes of your Emacs sessions. Simply loading uptimes.el from your
+;; uptimes of your Emacs sessions.  Simply loading uptimes.el from your
 ;; ~/.emacs file will start the tracking of any session.
 ;;
 ;; The latest version of uptimes.el can be found at:
@@ -209,32 +208,56 @@ The result is returned as the following `list':
             (create-lockfiles nil))     ; For the benefit of GNU emacs.
         (write-region (point-min) (point-max) uptimes-database nil 0)))))
 
-(defun uptimes-print-uptimes (list)
-  "Print uptimes list LIST to `standard-output'."
-  (princ "Boot                Endtime             Uptime       This emacs\n")
-  (princ "=================== =================== ============ ==========\n")
+(defun uptimes-tabulated-list-entries (source-list)
+  "Process SOURCE-LIST of uptimes into list entries for `uptimes-list-mode'."
   (cl-flet ((format-time (time)
-              (format-time-string "%Y-%m-%d %T" (uptimes-time-float time))))
-    (cl-loop for uptime in list
+                         (format-time-string "%Y-%m-%d %T" (uptimes-time-float time)))
+            (highlight-current (sig s) (if (string= sig (uptimes-key))
+                                           (propertize s 'face 'success)
+                                         s)))
+    (cl-loop for uptime in source-list
              for bootsig  = (car  uptime)
              for booted   = (cadr uptime)
              for snapshot = (cddr uptime)
-             do (princ (format "%19s %19s %12s %s\n"
-                               (format-time booted)
-                               (format-time snapshot)
-                               (uptimes-uptime-string booted snapshot)
-                               (if (string= bootsig (uptimes-key)) "<--" ""))))))
+             collect (list bootsig
+                           (vector
+                            (highlight-current bootsig (format-time booted))
+                            (highlight-current bootsig (format-time snapshot))
+                            (highlight-current bootsig (propertize (uptimes-uptime-string booted snapshot)
+                                                                   'duration (- snapshot booted))))))))
+
+(defun uptimes-sort-by-duration-pred (entry1 entry2)
+  "How to sort tabulated list entries ENTRY1 and ENTRY2 by their duration."
+  (> (get-text-property 1 'duration (elt (nth 1 entry1) 2))
+     (get-text-property 1 'duration (elt (nth 1 entry2) 2))))
+
+(define-derived-mode uptimes-list-mode tabulated-list-mode "uptimes"
+  "Show uptimes."
+  (setq tabulated-list-format
+        [("Boot" 20 t)
+         ("Endtime" 20 t)
+         ("Uptime" 12 uptimes-sort-by-duration-pred :right-align t)])
+  (setq tabulated-list-padding 2)
+  (tabulated-list-init-header)
+  (when (fboundp 'tablist-minor-mode)
+    (tablist-minor-mode)))
 
 ;;;###autoload
-(defun uptimes ()
-  "Display the last and top `uptimes-keep-count' uptimes."
-  (interactive)
+(defun uptimes (&optional top)
+  "Display the last `uptimes-keep-count' uptimes in a sortable table.
+With prefix argument TOP, the list is initially sorted to show
+the longest uptimes first."
+  (interactive "P")
   (uptimes-save)
-  (with-output-to-temp-buffer "*uptimes*"
-    (princ (format "Last %d uptimes\n\n" uptimes-keep-count))
-    (uptimes-print-uptimes uptimes-last-n)
-    (princ (format "\nTop %d uptimes\n\n" uptimes-keep-count))
-    (uptimes-print-uptimes uptimes-top-n)))
+  (with-current-buffer (get-buffer-create (if top "*top-uptimes*" "*uptimes*"))
+    (uptimes-list-mode)
+    (setq tabulated-list-sort-key
+          (if top '("Uptime" . nil) '("Boot" . t)))
+    (setq tabulated-list-entries
+          (apply-partially #'uptimes-tabulated-list-entries (if top uptimes-top-n uptimes-last-n)))
+    (tabulated-list-revert)
+    (goto-char (point-min))
+    (display-buffer (current-buffer))))
 
 ;;;###autoload
 (defun uptimes-current ()


### PR DESCRIPTION
This version of #5 / #6 displays the recent and top uptimes lists using tabulated-list-mode, but in separate buffers. I think this should address the confusion of mixing both lists together, as mentioned in [your comment](https://github.com/davep/uptimes.el/pull/6#issuecomment-453440895) on #6. If this looks vaguely reasonable, I can write a further change to provide a toggle key.