### PR TITLE
Fonts

### DIFF
--- a/uptimes.el
+++ b/uptimes.el
@@ -1,4 +1,4 @@
-;;; uptimes.el --- Track and display Emacs session uptimes.  -*- lexical-binding: t; -*-
+;;; uptimes.el --- Track and display session uptimes  -*- lexical-binding: t; -*-
 ;; Copyright 1999-2019 by Dave Pearson <davep@davep.org>
 
 ;; Author: Dave Pearson <davep@davep.org>

--- a/uptimes.el
+++ b/uptimes.el
@@ -331,6 +331,7 @@ See `uptimes-print-uptime' for other ways to customize the output."
       (uptimes-print-uptimes "Top %d uptimes" uptimes-top-n)
       (unless uptimes-show-last-uptimes-first
         (uptimes-print-uptimes "Last %d uptimes" uptimes-last-n))
+      (setq-local revert-buffer-function (lambda (&rest _ignored) (uptimes))) ; g refreshes buffer
       )))
 
 ;;;###autoload

--- a/uptimes.el
+++ b/uptimes.el
@@ -37,9 +37,6 @@
 ;;
 ;; Doug Elias <dme7@cornell.edu> for pointing out that midnight.el is a
 ;; recent addition to emacs.
-;;
-;; Nix <nix@esperi.demon.co.uk> for pointing out that some XEmacs users
-;; might need `inhibit-clash-detection' set to t at points in this code.
 
 ;;; Code:
 

--- a/uptimes.el
+++ b/uptimes.el
@@ -99,8 +99,8 @@
   :group 'uptimes)
 
 (defvar uptimes-headings-string
-  (concat    "\n\nBoot                Endtime             Uptime       This emacs\n"
-             "=================== =================== ============ ==========\n")
+  (concat "\n\nBoot                Endtime             Uptime       This emacs\n"
+          "=================== =================== ============ ==========\n")
   "String of column headings in an `uptimes' buffer.
 This is shown after the header, and before the list of uptimes above each list.
 The face `uptimes-headings-face' is used.")

--- a/uptimes.el
+++ b/uptimes.el
@@ -331,8 +331,7 @@ See `uptimes-print-uptime' for other ways to customize the output."
       (uptimes-print-uptimes "Top %d uptimes" uptimes-top-n)
       (unless uptimes-show-last-uptimes-first
         (uptimes-print-uptimes "Last %d uptimes" uptimes-last-n))
-      (setq-local revert-buffer-function (lambda (&rest _ignored) (uptimes))) ; g refreshes buffer
-      )))
+      (setq-local revert-buffer-function (lambda (&rest _ignored) (uptimes)))))) ; g refreshes buffer
 
 ;;;###autoload
 (defun uptimes-current ()


### PR DESCRIPTION
Allow the output of `uptimes' to be customised

Basically i wanted to make a lot of superficial changes to the appearance of *uptimes*,  including the order in which things appear, the column headings, how timestamps/duration appear, and the "<--" indicator, and to have a bit of colour. This is all documented in the first commit. 

The defaults should be the unchanged from v3.8, apart from adding some colour (if you prefer, i could make all the faces inherit from `default' so the default is identical)

The second commit sets revert-function in *uptimes* so that a `g' does a refresh
